### PR TITLE
Add test case with k=100.

### DIFF
--- a/benchmarks/benchmarks/kclass.py
+++ b/benchmarks/benchmarks/kclass.py
@@ -6,7 +6,7 @@ class KClass:
     # dims is (n, mx, k, mc)
     params = [
         ["liml", "tsls", 0.5],
-        [(1000, 1, 1, 0), (1000, 2, 4, 0), (1000, 2, 4, 2), "guggenberger12 (k=10)"],
+        [(1000, 1, 1, 0), (1000, 2, 100, 0), (1000, 2, 4, 2), "guggenberger12 (k=10)"],
     ]
     param_names = ["kappa", "data"]
 

--- a/benchmarks/benchmarks/tests.py
+++ b/benchmarks/benchmarks/tests.py
@@ -15,7 +15,7 @@ class Tests:
     # data is (k, mx, mw, mc)
     params = [
         [1000],
-        [(1, 1, 0, 0), (10, 1, 4, 0), (4, 2, 2, 2), "guggenberger12 (k=10)"],
+        [(1, 1, 0, 0), (100, 1, 4, 0), (4, 2, 2, 2), "guggenberger12 (k=10)"],
     ]
     param_names = ["n", "data"]
 

--- a/ivmodels/tests/anderson_rubin.py
+++ b/ivmodels/tests/anderson_rubin.py
@@ -189,8 +189,7 @@ def anderson_rubin_test(
         )
         dfn = k
     else:
-        spectrum = KClass._spectrum(X=W, y=y - X @ beta, Z=Z)
-        ar = np.min(spectrum)
+        ar = KClass._spectrum(X=W, y=y - X @ beta, Z=Z, subset_by_index=[0, 0])[0]
         dfn = k - W.shape[1]
 
     statistic = ar * (n - k - C.shape[1]) / dfn
@@ -206,7 +205,10 @@ def anderson_rubin_test(
                 "only available for the subvector variant where W is not None."
             )
 
-        kappa_max = (n - k - C.shape[1]) * np.max(spectrum)
+        mw = W.shape[1]
+        kappa_max = (n - k - C.shape[1]) * KClass._spectrum(
+            X=W, y=y - X @ beta, Z=Z, subset_by_index=[mw, mw]
+        )[0]
         p_value = more_powerful_subvector_anderson_rubin_critical_value_function(
             statistic * dfn, kappa_max, k, mw=W.shape[1]
         )

--- a/ivmodels/tests/likelihood_ratio.py
+++ b/ivmodels/tests/likelihood_ratio.py
@@ -91,8 +91,11 @@ def likelihood_ratio_test(Z, X, y, beta, W=None, C=None, fit_intercept=True):
     XWy = np.concatenate([X, W, y.reshape(-1, 1)], axis=1)
     XWy_proj = np.concatenate([X_proj, W_proj, y_proj.reshape(-1, 1)], axis=1)
 
-    matrix = np.linalg.solve(XWy.T @ (XWy - XWy_proj), XWy_proj.T @ XWy)
-    ar_min = (n - k - C.shape[1]) * min(np.abs(scipy.linalg.eigvals(matrix)))
+    ar_min = (n - k - C.shape[1]) * np.real(
+        scipy.linalg.eigvalsh(
+            a=XWy.T @ XWy_proj, b=XWy.T @ (XWy - XWy_proj), subset_by_index=[0, 0]
+        )[0]
+    )
 
     if W.shape[1] == 0:
         statistic = (n - k - C.shape[1]) * np.linalg.norm(
@@ -103,9 +106,10 @@ def likelihood_ratio_test(Z, X, y, beta, W=None, C=None, fit_intercept=True):
         Wy_proj = np.concatenate(
             [W_proj, (y_proj - X_proj @ beta).reshape(-1, 1)], axis=1
         )
-        matrix = np.linalg.solve(Wy.T @ (Wy - Wy_proj), Wy_proj.T @ Wy)
-        statistic = (n - k - C.shape[1]) * min(
-            np.abs(scipy.linalg.eigvals(matrix))
+        statistic = (n - k - C.shape[1]) * np.real(
+            scipy.linalg.eigvalsh(
+                a=Wy.T @ Wy_proj, b=Wy.T @ (Wy - Wy_proj), subset_by_index=[0, 0]
+            )[0]
         ) - ar_min
 
     p_value = 1 - scipy.stats.chi2.cdf(statistic, df=mx)
@@ -170,8 +174,11 @@ def inverse_likelihood_ratio_test(
     Xy_proj = np.concatenate([X_proj, y_proj.reshape(-1, 1)], axis=1)
     Xy = np.concatenate([X, y.reshape(-1, 1)], axis=1)
 
-    matrix = np.linalg.solve(Xy.T @ (Xy - Xy_proj), Xy.T @ Xy_proj)
-    kappa_liml = min(np.abs(np.linalg.eigvals(matrix)))
+    kappa_liml = np.real(
+        scipy.linalg.eigvalsh(
+            a=Xy.T @ Xy_proj, b=Xy.T @ (Xy - Xy_proj), subset_by_index=[0, 0]
+        )[0]
+    )
 
     dfd = n - k - C.shape[1]
     quantile = scipy.stats.chi2.ppf(1 - alpha, df=mx) + dfd * kappa_liml

--- a/ivmodels/tests/rank.py
+++ b/ivmodels/tests/rank.py
@@ -61,8 +61,11 @@ def rank_test(Z, X, C=None, fit_intercept=True):
 
     X_proj = proj(Z, X)
 
-    W = np.linalg.solve(X.T @ (X - X_proj), X.T @ X_proj)
-    statistic = (n - k - C.shape[1]) * min(np.real(np.linalg.eigvals(W)))
+    statistic = (n - k - C.shape[1]) * np.real(
+        scipy.linalg.eigvalsh(
+            a=X.T @ X_proj, b=X.T @ (X - X_proj), subset_by_index=[0, 0]
+        )[0]
+    )
     cdf = scipy.stats.chi2.cdf(statistic, df=(k - m + 1))
 
     return statistic, 1 - cdf


### PR DESCRIPTION
`conditional_likelihood_ratio_test`:
With
```python
        mat = scipy.linalg.sqrtm(np.linalg.inv((XWy - XWy_proj).T @ XWy))
        XWy_eigenvals = np.sort(
            np.real(
                scipy.linalg.eigvalsh(
                    mat.T @ XWy_proj.T @ XWy @ mat, subset_by_index=[0, 1]
                )
            )
        )
```
I get
```
[ 0.00%] ·· Benchmarking existing-py_Users_mlondschien_mambaforge_envs_ivmodels_bin_python
[25.00%] ··· Running (tests.Tests.time_conditional_likelihood_ratio_test_numerical_integration--)..
[75.00%] ··· tests.Tests.time_conditional_likelihood_ratio_test_numerical_integration                                                                      ok
[75.00%] ··· ====== ============== ================ ============== =======================
             --                                      data                                 
             ------ ----------------------------------------------------------------------
               n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
             ====== ============== ================ ============== =======================
              1000     849±9μs         171±2ms       1.76±0.01ms          29.1±0.1ms      
             ====== ============== ================ ============== =======================

[100.00%] ··· tests.Tests.time_conditional_likelihood_ratio_test_power_series                                                                               ok
[100.00%] ··· ====== ============== ================ ============== =======================
              --                                      data                                 
              ------ ----------------------------------------------------------------------
                n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
              ====== ============== ================ ============== =======================
               1000     855±5μs        3.31±0.02s     1.72±0.03ms         5.26±0.07ms      
              ====== ============== ================ ============== =======================
```

With 
```python
        XWy_eigenvals = np.sort(
            np.real(
                scipy.linalg.eigvals(
                    np.linalg.solve((XWy - XWy_proj).T @ XWy, XWy_proj.T @ XWy)
                )
            )
        )
```
I get
```
· Running 2 total benchmarks (1 commits * 1 environments * 2 benchmarks)
[ 0.00%] ·· Benchmarking existing-py_Users_mlondschien_mambaforge_envs_ivmodels_bin_python
[25.00%] ··· Running (tests.Tests.time_conditional_likelihood_ratio_test_numerical_integration--)..
[75.00%] ··· tests.Tests.time_conditional_likelihood_ratio_test_numerical_integration                                                                      ok
[75.00%] ··· ====== ============== ================ ============== =======================
             --                                      data                                 
             ------ ----------------------------------------------------------------------
               n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
             ====== ============== ================ ============== =======================
              1000     557±20μs        137±9ms       1.18±0.03ms         17.3±0.07ms      
             ====== ============== ================ ============== =======================

[100.00%] ··· tests.Tests.time_conditional_likelihood_ratio_test_power_series                                                                               ok
[100.00%] ··· ====== ============== ================ ============== =======================
              --                                      data                                 
              ------ ----------------------------------------------------------------------
                n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
              ====== ============== ================ ============== =======================
               1000     563±6μs         1.99±0s       1.15±0.01ms         3.63±0.06ms      
              ====== ============== ================ ============== =======================
```