### PR TITLE
Speed up clr

### DIFF
--- a/ivmodels/tests/conditional_likelihood_ratio.py
+++ b/ivmodels/tests/conditional_likelihood_ratio.py
@@ -92,8 +92,10 @@ def conditional_likelihood_ratio_critical_value_function(
         integrand.argtypes = (ctypes.c_double, ctypes.c_void_p)
 
         a = s_min / (z + s_min)
+        alpha = (q - p) / 2
+        beta = p / 2
         # Create a NumPy array with the parameter values
-        params = np.array([a, z, (q - p) / 2, p / 2, q], dtype=np.double)
+        params = np.array([a, z, alpha, beta, q], dtype=np.double)
 
         # Convert the parameter array to a ctypes pointer
         params_ctypes = params.ctypes.data_as(ctypes.POINTER(ctypes.c_double))
@@ -111,7 +113,7 @@ def conditional_likelihood_ratio_critical_value_function(
             epsabs=tol,
         )
 
-        return 1 - res[0]
+        return 1 - res[0] / scipy.special.beta(alpha, beta)
 
     elif method == "power_series":
         a = s_min / (z + s_min)

--- a/ivmodels/tests/integrand.c
+++ b/ivmodels/tests/integrand.c
@@ -1,0 +1,29 @@
+#include <math.h>
+#include <gsl/gsl_cdf.h>
+#include <gsl/gsl_sf_gamma.h>
+#include <gsl/gsl_randist.h>
+
+// Parameters struct to hold the values of a and z
+typedef struct {
+    double a;
+    double z;
+    double alpha;
+    double beta;
+} Params;
+
+// C function to compute the integrand
+double integrand(double b, void *params) {
+    Params *x = (Params *) params;
+    double a = x->a;
+    double z = x->z;
+    double alpha = x->alpha;
+    double beta = x->beta;
+    
+    // Compute beta pdf (assuming alpha=2 and beta=2 for this example)
+    double beta_pdf = gsl_ran_beta_pdf(b, alpha, beta);
+    
+    // Compute chi-squared cdf
+    double chi2_cdf = gsl_cdf_chisq_P(z / (1.0 - a * b), 1);
+    
+    return beta_pdf * chi2_cdf;
+}

--- a/ivmodels/tests/integrand.c
+++ b/ivmodels/tests/integrand.c
@@ -12,18 +12,20 @@ typedef struct {
 } Params;
 
 // C function to compute the integrand
-double integrand(double b, void *params) {
-    Params *x = (Params *) params;
-    double a = x->a;
-    double z = x->z;
-    double alpha = x->alpha;
-    double beta = x->beta;
-    
-    // Compute beta pdf (assuming alpha=2 and beta=2 for this example)
-    double beta_pdf = gsl_ran_beta_pdf(b, alpha, beta);
-    
+double integrand(double x, void *user_data) {
+    double *p = (double *)user_data;
+
+    double a = p[0];
+    double z = p[1];
+    double alpha = p[2];
+    double beta = p[3];
+    int k = (int) p[4];
+
+    // Compute beta pdf using the provided alpha and beta
+    double beta_pdf = gsl_ran_beta_pdf(x, alpha, beta);
+
     // Compute chi-squared cdf
-    double chi2_cdf = gsl_cdf_chisq_P(z / (1.0 - a * b), 1);
-    
+    double chi2_cdf = gsl_cdf_chisq_P(z / (1.0 - a * x), k);
+
     return beta_pdf * chi2_cdf;
 }

--- a/ivmodels/tests/integrand.c
+++ b/ivmodels/tests/integrand.c
@@ -21,10 +21,7 @@ double integrand(double x, void *user_data) {
     double beta = p[3];
     int k = (int) p[4];
 
-    // Compute beta pdf using the provided alpha and beta
-    double beta_pdf = gsl_ran_beta_pdf(x, alpha, beta);
-
-    // Compute chi-squared cdf
+    double beta_pdf = exp(log(x) * (alpha - 1) + log(1 - x) * (beta - 1));
     double chi2_cdf = gsl_cdf_chisq_P(z / (1.0 - a * x), k);
 
     return beta_pdf * chi2_cdf;

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+from setuptools import setup, Extension
+from Cython.Build import cythonize
+import numpy as np
+
+ext_modules = [
+    Extension(
+        "integrand",
+        sources=["ivmodels/tests/integrand.pyx"],
+        libraries=["gsl", "gslcblas"],
+        library_dirs=["/opt/homebrew/lib"],
+        include_dirs=["/opt/homebrew/include", np.get_include()],
+        extra_compile_args=["-fPIC"]
+    )
+]
+
+setup(
+    name="integrand",
+    ext_modules=cythonize(ext_modules),
+)


### PR DESCRIPTION
Main:
```
· Discovering benchmarks
· Running 2 total benchmarks (1 commits * 1 environments * 2 benchmarks)
[ 0.00%] ·· Benchmarking existing-py_Users_mlondschien_mambaforge_envs_ivmodels_bin_python
[25.00%] ··· Running (tests.Tests.time_conditional_likelihood_ratio_test_numerical_integration--)..
[75.00%] ··· tests.Tests.time_conditional_likelihood_ratio_test_numerical_integration                                                                      ok
[75.00%] ··· ====== ============== ================ ============== =======================
             --                                      data                                 
             ------ ----------------------------------------------------------------------
               n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
             ====== ============== ================ ============== =======================
              1000     451±5μs         72.4±2ms      1.09±0.01ms          16.7±0.1ms      
             ====== ============== ================ ============== =======================

[100.00%] ··· tests.Tests.time_conditional_likelihood_ratio_test_power_series                                                                               ok
[100.00%] ··· ====== ============== ================ ============== =======================
              --                                      data                                 
              ------ ----------------------------------------------------------------------
                n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
              ====== ============== ================ ============== =======================
               1000     449±1μs        1.90±0.01s     1.10±0.01ms         2.81±0.03ms      
              ====== ============== ================ ============== =======================
```

here:
```
[ 0.00%] ·· Benchmarking existing-py_Users_mlondschien_mambaforge_envs_ivmodels_bin_python
[50.00%] ··· Running (tests.Tests.time_conditional_likelihood_ratio_test_numerical_integration--).
[100.00%] ··· tests.Tests.time_conditional_likelihood_ratio_test_numerical_integration                                                                      ok
[100.00%] ··· ====== ============== ================ ============== =======================
              --                                      data                                 
              ------ ----------------------------------------------------------------------
                n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
              ====== ============== ================ ============== =======================
               1000     456±7μs         37.9±2ms      1.08±0.02ms         1.01±0.01ms      
              ====== ============== ================ ============== =======================
```

honestly less of a speed-up than expected.