### PR TITLE
Use `scipy.linalg.lstsq` instead of `np.linalg.lstsq`

### DIFF
--- a/ivmodels/utils.py
+++ b/ivmodels/utils.py
@@ -8,10 +8,7 @@ try:
 except ImportError:
     _PANDAS_INSTALLED = False
 
-import line_profiler
 
-
-@line_profiler.profile
 def proj(Z, *args):
     """Project f onto the subspace spanned by Z.
 

--- a/ivmodels/utils.py
+++ b/ivmodels/utils.py
@@ -37,6 +37,10 @@ def proj(Z, *args):
             raise ValueError(f"Shape mismatch: Z.shape={Z.shape}, f.shape={f.shape}.")
 
     if len(args) == 1:
+        # The gelsy driver raises in this case - we handle it separately
+        if len(args[0].shape) == 2 and args[0].shape[1] == 0:
+            return np.zeros_like(args[0])
+
         return np.dot(
             Z, scipy.linalg.lstsq(Z, args[0], cond=None, lapack_driver="gelsy")[0]
         )
@@ -45,6 +49,11 @@ def proj(Z, *args):
     csum = [0] + csum.tolist()
 
     fs = np.hstack([f.reshape(Z.shape[0], -1) for f in args])
+
+    if fs.shape[1] == 0:
+        # The gelsy driver raises in this case - we handle it separately
+        return (*(np.zeros_like(f) for f in args),)
+
     fs = np.dot(Z, scipy.linalg.lstsq(Z, fs, cond=None, lapack_driver="gelsy")[0])
 
     return (

--- a/ivmodels/utils.py
+++ b/ivmodels/utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+import scipy
 
 try:
     import pandas as pd
@@ -7,7 +8,10 @@ try:
 except ImportError:
     _PANDAS_INSTALLED = False
 
+import line_profiler
 
+
+@line_profiler.profile
 def proj(Z, *args):
     """Project f onto the subspace spanned by Z.
 
@@ -36,13 +40,15 @@ def proj(Z, *args):
             raise ValueError(f"Shape mismatch: Z.shape={Z.shape}, f.shape={f.shape}.")
 
     if len(args) == 1:
-        return np.dot(Z, np.linalg.lstsq(Z, args[0], rcond=None)[0])
+        return np.dot(
+            Z, scipy.linalg.lstsq(Z, args[0], cond=None, lapack_driver="gelsy")[0]
+        )
 
     csum = np.cumsum([f.shape[1] if len(f.shape) == 2 else 1 for f in args])
     csum = [0] + csum.tolist()
 
     fs = np.hstack([f.reshape(Z.shape[0], -1) for f in args])
-    fs = np.dot(Z, np.linalg.lstsq(Z, fs, rcond=None)[0])
+    fs = np.dot(Z, scipy.linalg.lstsq(Z, fs, cond=None, lapack_driver="gelsy")[0])
 
     return (
         *(fs[:, i:j].reshape(f.shape) for i, j, f in zip(csum[:-1], csum[1:], args)),
@@ -68,26 +74,11 @@ def oproj(Z, *args):
     if Z is None:
         return (*args,)
 
-    for f in args:
-        if len(f.shape) > 2:
-            raise ValueError(
-                f"*args should have shapes (n, d_f) or (n,). Got {f.shape}."
-            )
-        if f.shape[0] != Z.shape[0]:
-            raise ValueError(f"Shape mismatch: Z.shape={Z.shape}, f.shape={f.shape}.")
-
     if len(args) == 1:
-        return args[0] - np.dot(Z, np.linalg.lstsq(Z, args[0], rcond=None)[0])
+        return args[0] - proj(Z, args[0])
 
-    csum = np.cumsum([f.shape[1] if len(f.shape) == 2 else 1 for f in args])
-    csum = [0] + csum.tolist()
-
-    fs = np.hstack([f.reshape(Z.shape[0], -1) for f in args])
-    fs = fs - np.dot(Z, np.linalg.lstsq(Z, fs, rcond=None)[0])
-
-    return (
-        *(fs[:, i:j].reshape(f.shape) for i, j, f in zip(csum[:-1], csum[1:], args)),
-    )
+    else:
+        return (*(x - x_proj for x, x_proj in zip(args, proj(Z, *args))),)
 
 
 def to_numpy(x):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,6 +36,11 @@ def test_proj_multiple_args():
     )
     assert np.allclose(proj(X, z1), X @ np.linalg.inv(X.T @ X) @ X.T @ z1)
     assert np.allclose(proj(X, z2), X @ np.linalg.inv(X.T @ X) @ X.T @ z2)
+    assert np.allclose(
+        proj(X, z2, z2),
+        X @ np.linalg.inv(X.T @ X) @ X.T @ z2,
+        X @ np.linalg.inv(X.T @ X) @ X.T @ z2,
+    )
     assert np.allclose(proj(X, z3), X @ np.linalg.inv(X.T @ X) @ X.T @ z3)
 
 


### PR DESCRIPTION
here:
```
· Running 9 total benchmarks (1 commits * 1 environments * 9 benchmarks)
[ 0.00%] ·· Benchmarking existing-py_Users_mlondschien_mambaforge_envs_ivmodels_bin_python
[ 5.56%] ··· Running (kclass.KClass.time_fit--).....
[33.33%] ··· Running (tests.Tests.time_lagrange_multiplier_test--)....
[55.56%] ··· kclass.KClass.time_fit                                                                                                                        ok
[55.56%] ··· ======= ================= =================== ================= =======================
             --                                            data                                     
             ------- -------------------------------------------------------------------------------
              kappa   (1000, 1, 1, 0)   (1000, 2, 100, 0)   (1000, 2, 4, 2)   guggenberger12 (k=10) 
             ======= ================= =================== ================= =======================
               liml       151±5μs           4.93±0.6ms          323±8μs              263±5μs        
               tsls     1.34±0.03ms          12.2±5ms         1.62±0.05ms          1.64±0.03ms      
               0.5      1.38±0.03ms         8.95±0.9ms        1.58±0.08ms          1.63±0.04ms      
             ======= ================= =================== ================= =======================

[61.11%] ··· tests.Tests.time_anderson_rubin_test                                                                                                          ok
[61.11%] ··· ====== ============== ================ ============== =======================
             --                                      data                                 
             ------ ----------------------------------------------------------------------
               n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
             ====== ============== ================ ============== =======================
              1000     104±2μs         8.97±3ms        312±10μs            333±10μs       
             ====== ============== ================ ============== =======================

[66.67%] ··· tests.Tests.time_anderson_rubin_test_guggenberger19                                                                                           ok
[66.67%] ··· ====== ============== ================ ============== =======================
             --                                      data                                 
             ------ ----------------------------------------------------------------------
               n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
             ====== ============== ================ ============== =======================
              1000       n/a           17.9±6ms        413±7μs             568±7μs        
             ====== ============== ================ ============== =======================

[72.22%] ··· tests.Tests.time_conditional_likelihood_ratio_test_numerical_integration                                                                      ok
[72.22%] ··· ====== ============== ================ ============== =======================
             --                                      data                                 
             ------ ----------------------------------------------------------------------
               n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
             ====== ============== ================ ============== =======================
              1000     456±6μs         15.5±3ms        922±6μs             704±10μs       
             ====== ============== ================ ============== =======================

[77.78%] ··· tests.Tests.time_conditional_likelihood_ratio_test_power_series                                                                               ok
[77.78%] ··· ====== ============== ================ ============== =======================
             --                                      data                                 
             ------ ----------------------------------------------------------------------
               n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
             ====== ============== ================ ============== =======================
              1000     458±6μs        2.04±0.07s       973±20μs           2.80±0.1ms      
             ====== ============== ================ ============== =======================

[83.33%] ··· tests.Tests.time_lagrange_multiplier_test                                                                                                     ok
[83.33%] ··· ====== ============== ================ ============== =======================
             --                                      data                                 
             ------ ----------------------------------------------------------------------
               n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
             ====== ============== ================ ============== =======================
              1000     145±2μs         28.5±7ms      2.96±0.04ms         2.82±0.03ms      
             ====== ============== ================ ============== =======================

[88.89%] ··· tests.Tests.time_likelihood_ratio_test                                                                                                        ok
[88.89%] ··· ====== ============== ================ ============== =======================
             --                                      data                                 
             ------ ----------------------------------------------------------------------
               n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
             ====== ============== ================ ============== =======================
              1000     160±2μs         6.30±1ms        389±10μs            382±7μs        
             ====== ============== ================ ============== =======================

[94.44%] ··· tests.Tests.time_wald_test_liml                                                                                                               ok
[94.44%] ··· ====== ============== ================ ============== =======================
             --                                      data                                 
             ------ ----------------------------------------------------------------------
               n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
             ====== ============== ================ ============== =======================
              1000     361±5μs        14.3±10ms        844±8μs             853±20μs       
             ====== ============== ================ ============== =======================

[100.00%] ··· tests.Tests.time_wald_test_tsls                                                                                                               ok
[100.00%] ··· ====== ============== ================ ============== =======================
              --                                      data                                 
              ------ ----------------------------------------------------------------------
                n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
              ====== ============== ================ ============== =======================
               1000   1.67±0.05ms       19.6±3ms      2.19±0.04ms         2.37±0.07ms      
              ====== ============== ================ ============== =======================
```

main: 
```
[ 0.00%] ·· Benchmarking existing-py_Users_mlondschien_mambaforge_envs_ivmodels_bin_python
[ 5.56%] ··· Running (kclass.KClass.time_fit--).....
[33.33%] ··· Running (tests.Tests.time_lagrange_multiplier_test--)....
[55.56%] ··· kclass.KClass.time_fit                                                                                                                        ok
[55.56%] ··· ======= ================= =================== ================= =======================
             --                                            data                                     
             ------- -------------------------------------------------------------------------------
              kappa   (1000, 1, 1, 0)   (1000, 2, 100, 0)   (1000, 2, 4, 2)   guggenberger12 (k=10) 
             ======= ================= =================== ================= =======================
               liml       137±3μs           17.9±0.7ms          303±7μs              303±5μs        
               tsls     1.37±0.04ms         18.9±0.7ms        1.54±0.03ms          1.56±0.05ms      
               0.5      1.34±0.03ms         19.1±0.6ms        1.53±0.02ms          1.56±0.09ms      
             ======= ================= =================== ================= =======================

[61.11%] ··· tests.Tests.time_anderson_rubin_test                                                                                                          ok
[61.11%] ··· ====== ============== ================ ============== =======================
             --                                      data                                 
             ------ ----------------------------------------------------------------------
               n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
             ====== ============== ================ ============== =======================
              1000    93.9±0.3μs       19.0±2ms        412±5μs             478±20μs       
             ====== ============== ================ ============== =======================

[66.67%] ··· tests.Tests.time_anderson_rubin_test_guggenberger19                                                                                           ok
[66.67%] ··· ====== ============== ================ ============== =======================
             --                                      data                                 
             ------ ----------------------------------------------------------------------
               n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
             ====== ============== ================ ============== =======================
              1000       n/a          35.3±0.9ms       517±7μs             737±9μs        
             ====== ============== ================ ============== =======================

[72.22%] ··· tests.Tests.time_conditional_likelihood_ratio_test_numerical_integration                                                                      ok
[72.22%] ··· ====== ============== ================ ============== =======================
             --                                      data                                 
             ------ ----------------------------------------------------------------------
               n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
             ====== ============== ================ ============== =======================
              1000     458±10μs        41.3±3ms      1.15±0.02ms           867±9μs        
             ====== ============== ================ ============== =======================

[77.78%] ··· tests.Tests.time_conditional_likelihood_ratio_test_power_series                                                                               ok
[77.78%] ··· ====== ============== ================ ============== =======================
             --                                      data                                 
             ------ ----------------------------------------------------------------------
               n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
             ====== ============== ================ ============== =======================
              1000     460±8μs        1.95±0.02s     1.19±0.04ms         2.79±0.04ms      
             ====== ============== ================ ============== =======================

[83.33%] ··· tests.Tests.time_lagrange_multiplier_test                                                                                                     ok
[83.33%] ··· ====== ============== ================ ============== =======================
             --                                      data                                 
             ------ ----------------------------------------------------------------------
               n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
             ====== ============== ================ ============== =======================
              1000     133±2μs         46.9±2ms      3.03±0.04ms         2.97±0.03ms      
             ====== ============== ================ ============== =======================

[88.89%] ··· tests.Tests.time_likelihood_ratio_test                                                                                                        ok
[88.89%] ··· ====== ============== ================ ============== =======================
             --                                      data                                 
             ------ ----------------------------------------------------------------------
               n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
             ====== ============== ================ ============== =======================
              1000     168±50μs       20.1±0.9ms       492±9μs             525±4μs        
             ====== ============== ================ ============== =======================

[94.44%] ··· tests.Tests.time_wald_test_liml                                                                                                               ok
[94.44%] ··· ====== ============== ================ ============== =======================
             --                                      data                                 
             ------ ----------------------------------------------------------------------
               n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
             ====== ============== ================ ============== =======================
              1000     343±7μs         40.8±2ms        901±20μs            1.00±0ms       
             ====== ============== ================ ============== =======================

[100.00%] ··· tests.Tests.time_wald_test_tsls                                                                                                               ok
[100.00%] ··· ====== ============== ================ ============== =======================
              --                                      data                                 
              ------ ----------------------------------------------------------------------
                n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
              ====== ============== ================ ============== =======================
               1000   1.61±0.06ms       37.6±2ms      2.15±0.05ms         2.21±0.03ms      
              ====== ============== ================ ============== =======================
```