### PR TITLE
Speed up lm test

### DIFF
--- a/ivmodels/tests/lagrange_multiplier.py
+++ b/ivmodels/tests/lagrange_multiplier.py
@@ -140,58 +140,58 @@ class _LM:
         St_orth = St - St_proj
 
         mat = St_proj.T @ St_proj
-        cond = np.linalg.cond(mat)
-        if cond > 1e12:
-            mat += 1e-6 * np.eye(mat.shape[0])
+        # cond = np.linalg.cond(mat)
+        # if cond > 1e12:
+        #     mat += 1e-6 * np.eye(mat.shape[0])
 
-        solved = np.linalg.solve(
-            mat,
-            np.hstack(
-                [
-                    St_proj.T @ residuals_proj.reshape(-1, 1),
-                    St_orth.T @ St[:, self.mx :],
-                ]
-            ),
-        )
-        residuals_proj_St = St_proj @ solved[:, 0]
+        solved = np.linalg.solve(mat, St_proj.T @ residuals_proj)
+        #     mat,
+        #     np.hstack(
+        #         [
+        #             St_proj.T @ residuals_proj.reshape(-1, 1),
+        #             St_orth.T @ St[:, self.mx :],
+        #         ]
+        #     ),
+        # )
+        residuals_proj_St = St_proj @ solved
 
         ar = residuals_proj.T @ residuals_proj / sigma_hat
         lm = residuals_proj_St.T @ residuals_proj_St / sigma_hat
         kappa = ar - lm
 
         first_term = -St_proj[:, self.mx :].T @ residuals_proj
-        second_term = St_orth[:, self.mx :].T @ St @ solved[:, 0]
-        S = self.yS[:, 1:]
-        S_proj = self.yS_proj[:, 1:]
-        S_orth = S - S_proj
+        second_term = St_orth[:, self.mx :].T @ St @ solved
+        # S = self.yS[:, 1:]
+        # S_proj = self.yS_proj[:, 1:]
+        # S_orth = S - S_proj
 
         d_lm = 2 * (first_term + kappa * second_term) / sigma_hat
 
-        dd_lm = (
-            2
-            * (
-                -3 * kappa * np.outer(second_term, second_term) / sigma_hat
-                + kappa**2 * St_orth[:, self.mx :].T @ St_orth @ solved[:, 1:]
-                - kappa * St_orth[:, self.mx :].T @ St_orth[:, self.mx :]
-                - kappa
-                * St_orth[:, self.mx :].T
-                @ St_orth
-                @ np.outer(solved[:, 0], Sigma[self.mx :])
-                + St[:, self.mx :].T
-                @ (S_proj[:, self.mx :] - ar * S_orth[:, self.mx :])
-                - np.outer(
-                    Sigma[self.mx :],
-                    (St_proj - kappa * St_orth)[:, self.mx :].T @ St @ solved[:, 0],
-                )
-                + 2
-                * kappa
-                * np.outer(S_orth[:, self.mx :].T @ St @ solved[:, 0], Sigma[self.mx :])
-                - 2 * np.outer(St_proj[:, self.mx :].T @ residuals, Sigma[self.mx :])
-            )
-            / sigma_hat
-        )
+        # dd_lm = (
+        #     2
+        #     * (
+        #         -3 * kappa * np.outer(second_term, second_term) / sigma_hat
+        #         + kappa**2 * St_orth[:, self.mx :].T @ St_orth @ solved[:, 1:]
+        #         - kappa * St_orth[:, self.mx :].T @ St_orth[:, self.mx :]
+        #         - kappa
+        #         * St_orth[:, self.mx :].T
+        #         @ St_orth
+        #         @ np.outer(solved[:, 0], Sigma[self.mx :])
+        #         + St[:, self.mx :].T
+        #         @ (S_proj[:, self.mx :] - ar * S_orth[:, self.mx :])
+        #         - np.outer(
+        #             Sigma[self.mx :],
+        #             (St_proj - kappa * St_orth)[:, self.mx :].T @ St @ solved[:, 0],
+        #         )
+        #         + 2
+        #         * kappa
+        #         * np.outer(S_orth[:, self.mx :].T @ St @ solved[:, 0], Sigma[self.mx :])
+        #         - 2 * np.outer(St_proj[:, self.mx :].T @ residuals, Sigma[self.mx :])
+        #     )
+        #     / sigma_hat
+        # )
 
-        return (self.dof * lm.item(), self.dof * d_lm.flatten(), self.dof * dd_lm)
+        return (self.dof * lm.item(), self.dof * d_lm.flatten(), None)
 
     def lm(self, beta):
         """
@@ -213,16 +213,16 @@ class _LM:
 
         objective = MemoizeJacHess(_derivative)
         jac = objective.derivative
-        hess = objective.hessian
+        # hess = objective.hessian
 
         res1 = scipy.optimize.minimize(
-            objective, jac=jac, hess=hess, x0=gamma_0, method="newton-cg"
+            objective, jac=jac, hess=None, x0=gamma_0, method="newton-cg"
         )
 
         res2 = scipy.optimize.minimize(
             objective,
             jac=jac,
-            hess=hess,
+            hess=None,
             method="newton-cg",
             x0=np.zeros_like(gamma_0),
         )

--- a/ivmodels/tests/lagrange_multiplier.py
+++ b/ivmodels/tests/lagrange_multiplier.py
@@ -162,18 +162,17 @@ class _LM:
         cond = np.linalg.cond(mat)
 
         if hess:
-            if cond > 1e8:
-                mat += 1e-8 * np.eye(mat.shape[0])
-
-            solved = np.linalg.solve(
-                mat,
-                np.hstack(
-                    [
-                        St_proj.T @ residuals_proj.reshape(-1, 1),
-                        St_orth.T @ St[:, self.mx :],
-                    ]
-                ),
+            f = np.hstack(
+                [
+                    St_proj.T @ residuals_proj.reshape(-1, 1),
+                    St_orth.T @ St[:, self.mx :],
+                ]
             )
+            if cond > 1e8:
+                solved = np.linalg.pinv(mat) @ f
+            else:
+                solved = np.linalg.solve(mat, f)
+
         else:
             # If mat is well conditioned, both should be equivalent, but the pinv
             # solution is defined even if mat is singular. In theory, solve should be

--- a/ivmodels/tests/lagrange_multiplier.py
+++ b/ivmodels/tests/lagrange_multiplier.py
@@ -213,16 +213,16 @@ class _LM:
 
         objective = MemoizeJacHess(_derivative)
         jac = objective.derivative
-        # hess = objective.hessian
+        hess = objective.hessian
 
         res1 = scipy.optimize.minimize(
-            objective, jac=jac, hess=None, x0=gamma_0, method="newton-cg"
+            objective, jac=jac, hess=hess, x0=gamma_0, method="newton-cg"
         )
 
         res2 = scipy.optimize.minimize(
             objective,
             jac=jac,
-            hess=None,
+            hess=hess,
             method="newton-cg",
             x0=np.zeros_like(gamma_0),
         )

--- a/ivmodels/tests/lagrange_multiplier.py
+++ b/ivmodels/tests/lagrange_multiplier.py
@@ -216,14 +216,14 @@ class _LM:
         # hess = objective.hessian
 
         res1 = scipy.optimize.minimize(
-            objective, jac=jac, hess=None, x0=gamma_0, method="newton-cg"
+            objective, jac=jac, hess=None, x0=gamma_0, method="bfgs"
         )
 
         res2 = scipy.optimize.minimize(
             objective,
             jac=jac,
             hess=None,
-            method="newton-cg",
+            method="bfgs",
             x0=np.zeros_like(gamma_0),
         )
 

--- a/tests/tests/test_lagrange_multiplier.py
+++ b/tests/tests/test_lagrange_multiplier.py
@@ -36,6 +36,7 @@ def test__LM__init__(n, mx, mw, k):
         [
             np.all(np.isclose(lm1.__dict__[k], lm2.__dict__[k]))
             for k in lm1.__dict__.keys()
+            if k not in ["optimizer", "gamma_0"]
         ]
     )
 

--- a/tests/tests/test_lagrange_multiplier.py
+++ b/tests/tests/test_lagrange_multiplier.py
@@ -55,23 +55,37 @@ def test_lm_gradient(n, mx, mw, k):
         beta = rng.normal(0, 1, mx)
         gamma = rng.normal(0, 1, mw)
 
-        grad_approx = scipy.optimize.approx_fprime(
+        grad_approx1 = scipy.optimize.approx_fprime(
             gamma,
-            lambda g: lm.derivative(beta=beta, gamma=g)[0],
+            lambda g: lm.derivative(beta=beta, gamma=g, jac=False, hess=False)[0],
             1e-6,
         )
-        grad = lm.derivative(beta, gamma)[1]
-
-        assert np.allclose(grad, grad_approx, rtol=5e-4, atol=5e-4)
-
-        hess_approx = scipy.optimize.approx_fprime(
+        grad_approx2 = scipy.optimize.approx_fprime(
             gamma,
-            lambda g: lm.derivative(beta=beta, gamma=g)[1],
+            lambda g: lm.derivative(beta=beta, gamma=g, jac=True, hess=True)[0],
             1e-6,
         )
-        hess = lm.derivative(beta, gamma)[2]
+        grad1 = lm.derivative(beta, gamma, jac=True, hess=False)[1]
+        grad2 = lm.derivative(beta, gamma, jac=True, hess=True)[1]
 
-        assert np.allclose(hess, hess_approx, rtol=5e-5, atol=5e-5)
+        assert np.allclose(grad1, grad_approx1, rtol=5e-4, atol=5e-4)
+        assert np.allclose(grad1, grad_approx2, rtol=5e-4, atol=5e-4)
+        assert np.allclose(grad1, grad2, rtol=5e-4, atol=5e-4)
+
+        hess_approx1 = scipy.optimize.approx_fprime(
+            gamma,
+            lambda g: lm.derivative(beta=beta, gamma=g, jac=True, hess=True)[1],
+            1e-6,
+        )
+        hess_approx2 = scipy.optimize.approx_fprime(
+            gamma,
+            lambda g: lm.derivative(beta=beta, gamma=g, jac=True, hess=False)[1],
+            1e-6,
+        )
+        hess = lm.derivative(beta, gamma, jac=True, hess=True)[2]
+
+        assert np.allclose(hess, hess_approx1, rtol=5e-5, atol=5e-5)
+        assert np.allclose(hess, hess_approx2, rtol=5e-5, atol=5e-5)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
main (compute hessian, don't use it, `newton-cg`):
```
[75.00%] ··· tests.Tests.time_inverse_lagrange_multiplier_test                                                                                                                                              ok
[75.00%] ··· ====== ============== ================ ============== =======================
             --                                      data                                 
             ------ ----------------------------------------------------------------------
               n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
             ====== ============== ================ ============== =======================
              1000    14.1±0.1ms       110±20ms          n/a             3.58±0.08ms      
             ====== ============== ================ ============== =======================

[100.00%] ··· tests.Tests.time_lagrange_multiplier_test                                                                                                                                                      ok
[100.00%] ··· ====== ============== ================ ============== =======================
              --                                      data                                 
              ------ ----------------------------------------------------------------------
                n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
              ====== ============== ================ ============== =======================
               1000     152±2μs         126±50ms       10.3±0.3ms          7.14±0.3ms      
              ====== ============== ================ ============== =======================
```

`37f2ab4` (compute hessian, use it, `newton-cg`):
```
[75.00%] ··· tests.Tests.time_inverse_lagrange_multiplier_test                                                                                                                                              ok
[75.00%] ··· ====== ============== ================ ============== =======================
             --                                      data                                 
             ------ ----------------------------------------------------------------------
               n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
             ====== ============== ================ ============== =======================
              1000    14.1±0.2ms       115±30ms          n/a              3.71±0.3ms      
             ====== ============== ================ ============== =======================

[100.00%] ··· tests.Tests.time_lagrange_multiplier_test                                                                                                                                                      ok
[100.00%] ··· ====== ============== ================ ============== =======================
              --                                      data                                 
              ------ ----------------------------------------------------------------------
                n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
              ====== ============== ================ ============== =======================
               1000    196±100μs        102±30ms       4.82±0.1ms          4.93±0.2ms      
              ====== ============== ================ ============== =======================
```

`5cfb2d1` (don't compute hessian, `newton-cg`):
```
[75.00%] ··· tests.Tests.time_inverse_lagrange_multiplier_test                                                                                                                                              ok
[75.00%] ··· ====== ============== ================ ============== =======================
             --                                      data                                 
             ------ ----------------------------------------------------------------------
               n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
             ====== ============== ================ ============== =======================
              1000   14.0±0.08ms      70.7±20ms          n/a             2.20±0.04ms      
             ====== ============== ================ ============== =======================

[100.00%] ··· tests.Tests.time_lagrange_multiplier_test                                                                                                                                                      ok
[100.00%] ··· ====== ============== ================ ============== =======================
              --                                      data                                 
              ------ ----------------------------------------------------------------------
                n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
              ====== ============== ================ ============== =======================
               1000     151±2μs        28.7±10ms      4.87±0.05ms         3.73±0.06ms      
              ====== ============== ================ ============== =======================
```

`bc7f67f`(don't compute hessian, `bfgs`):
```
[75.00%] ··· tests.Tests.time_inverse_lagrange_multiplier_test                                                                                                                                              ok
[75.00%] ··· ====== ============== ================ ============== =======================
             --                                      data                                 
             ------ ----------------------------------------------------------------------
               n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
             ====== ============== ================ ============== =======================
              1000    13.7±0.1ms      74.5±10ms          n/a              19.5±0.2ms      
             ====== ============== ================ ============== =======================

[100.00%] ··· tests.Tests.time_lagrange_multiplier_test                                                                                                                                                      ok
[100.00%] ··· ====== ============== ================ ============== =======================
              --                                      data                                 
              ------ ----------------------------------------------------------------------
                n     (1, 1, 0, 0)   (100, 1, 4, 0)   (4, 2, 2, 2)   guggenberger12 (k=10) 
              ====== ============== ================ ============== =======================
               1000     149±3μs        82.3±40ms      3.49±0.03ms         4.10±0.06ms      
              ====== ============== ================ ============== =======================
```